### PR TITLE
Generate a second feed for Zeal compatibility

### DIFF
--- a/.github/workflows/publish_docsets.yml
+++ b/.github/workflows/publish_docsets.yml
@@ -2,6 +2,7 @@ name: "Publish docsets to gh pages"
 on:
   workflow_call:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ However, they lack docsets for the nix cinematic universe, which this repo aims 
 
 The flake in this repo contains a package per docset for:
 
-* nix, the commandline tool and language
-* nixpkgs, the package collection and standard environment for building more packages
-* NixOS, the linux system based on nixpkgs
-* nix-darwin, the darwin configuration manager based on nixpkgs
-* home-manager, the home directory manager based on nixpkgs
+- nix, the commandline tool and language
+- nixpkgs, the package collection and standard environment for building more packages
+- NixOS, the linux system based on nixpkgs
+- nix-darwin, the darwin configuration manager based on nixpkgs
+- home-manager, the home directory manager based on nixpkgs
 
 All of them (except for NixOS, which requires linux platforms) are portable and can be built anywhere. I would suggest deploying them on a linux machine with a static file server serving the .tgz and .xml files.
 
@@ -24,25 +24,26 @@ The docsets get built daily and deployed to Github Pages, see the [nix dash docs
 
 In a nix flake, you'll generate the feeds, which are exposed as a function on this flake's `legacyPackages` attribute:
 
-## `nix-dash-docsets.legacyPackages.${system}.mkNixDocsetFeed {baseURL}`
+## `nix-dash-docsets.legacyPackages.${system}.mkNixDocsetFeed {baseURL, zealCompat}`
 
 Parameters passed via attrset:
 
-* `baseURL` - The absolute base URL (http or https) serving the generated directory. Dash can not deal with relative URLs here, and it requires a http or https URL in its docset feeds.
+- `baseURL` - The absolute base URL (http or https) serving the generated directory. Dash can not deal with relative URLs here, and it requires a http or https URL in its docset feeds.
+- `zealCompat` (default: `false`) - if set to true, generate feeds pointing to docset packages that can be imported by Zeal.
 
 This function builds the available docsets on the platform identified by `system` and writes them to its output directory.
 
 Once generated, you can add each of the following XML files as feeds in Dash's "Main Docsets" (under "Downloads") preferences, after clicking "+":
 
-* `{baseURL}/nix.xml`
-* `{baseURL}/nixos.xml`
-* `{baseURL}/nixpkgs.xml`
-* `{baseURL}/nix-darwin.xml`
-* `{baseURL}/home-manager.xml`
+- `{baseURL}/nix.xml`
+- `{baseURL}/nixos.xml`
+- `{baseURL}/nixpkgs.xml`
+- `{baseURL}/nix-darwin.xml`
+- `{baseURL}/home-manager.xml`
 
 ## Status: Incomplete
 
 This flake is by far not complete yet. Things I'd like to do (that work in my personal system config flake, which is of no benefit to you):
 
-* Add a `nixosModules.default` and `darwinModules.default` that allows configuring where the output packages go
-* Configure github actions to publish a static page of the generated docsets, with auto-updates.
+- Add a `nixosModules.default` and `darwinModules.default` that allows configuring where the output packages go
+- Configure github actions to publish a static page of the generated docsets, with auto-updates.

--- a/lib/buildDashDocset/default.nix
+++ b/lib/buildDashDocset/default.nix
@@ -38,7 +38,8 @@ in
 
     installPhase = ''
       mkdir -p $out/
-      tar zcf $out/${pname}.tgz ./${pname}.docset
+      tar -zcf $out/${pname}.tgz "${pname}.docset"
+      tar -zcf $out/${pname}-zeal.tgz -C "${pname}.docset" .
     '';
 
     nativeCheckInputs = [sqlite];
@@ -50,17 +51,17 @@ in
     in
       (lib.concatMapAttrsStringSep "\n" (name: type: ''
           echo "${name} should be ${type}"
-              if ! [ "$(sqlite3 -batch -bail ${pname}.docset/Contents/Resources/docSet.dsidx -cmd "select count(type) from searchIndex where name = '${name}' and type='${type}'" </dev/null)" = 1 ] ; then
-                echo " -- FAILED"
-                sqlite3 -json -batch -bail ${pname}.docset/Contents/Resources/docSet.dsidx -cmd "select * from searchIndex where name = '${name}'" </dev/null
-                exit 1
-              fi
+          if ! [ "$(sqlite3 -batch -bail ${pname}.docset/Contents/Resources/docSet.dsidx -cmd "select count(type) from searchIndex where name = '${name}' and type='${type}'" </dev/null)" = 1 ] ; then
+            echo " -- FAILED"
+            sqlite3 -json -batch -bail ${pname}.docset/Contents/Resources/docSet.dsidx -cmd "select * from searchIndex where name = '${name}'" </dev/null
+            exit 1
+          fi
         '')
         expectations)
       + "\n"
       + (lib.concatMapStringsSep "\n" (name: ''
           echo "${name} should be absent"
-            [ "$(sqlite3 -batch -bail ${pname}.docset/Contents/Resources/docSet.dsidx -cmd "select count(type) from searchIndex where name = '${name}'" </dev/null)" = 0 ]
+          [ "$(sqlite3 -batch -bail ${pname}.docset/Contents/Resources/docSet.dsidx -cmd "select count(type) from searchIndex where name = '${name}'" </dev/null)" = 0 ]
         '')
         absent);
   }

--- a/pages/flake.nix
+++ b/pages/flake.nix
@@ -20,10 +20,15 @@
       }: {
         packages.default = let
           docset-feeds = inputs'.docsets.legacyPackages.mkNixDocsetFeed {baseURL = "https://boinkor-net.github.io/nix-dash-docsets/daily";};
+          docset-feeds-zeal = inputs'.docsets.legacyPackages.mkNixDocsetFeed {
+            baseURL = "https://boinkor-net.github.io/nix-dash-docsets/daily-zeal";
+            zealCompat = true;
+          };
         in
           pkgs.runCommand "daily-docsets" {} ''
             mkdir -p $out
             ln -s ${docset-feeds} $out/daily
+            ln -s ${docset-feeds-zeal} $out/daily-zeal
             cp ${./index.html} $out/index.html
           '';
         formatter = pkgs.alejandra;

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,19 +1,46 @@
 <html>
-  <head><title>nix-related dash docsets</title></head>
+  <head>
+    <title>nix-related dash docsets</title>
+  </head>
   <body>
     <h1>Daily docsets (generation runs daily at 19:37 UTC)</h1>
     <p>
-      You can add each of these feeds to Dash by opening the
-      preferences, selecting "Downloads" and then in "Main Docsets",
-      clicking the "+" button. There, copy&paste the links to the
-      feeds that interest you below:
+      You can add each of these feeds to Dash by opening the preferences,
+      selecting "Downloads" and then in "Main Docsets", clicking the "+" button.
+      There, copy&paste the links to the feeds that interest you below:
+    </p>
+    <p>
+      If you use Zeal, please use each entry's <tt>[zeal]</tt> link. (See
+      <a href="https://github.com/boinkor-net/nix-dash-docsets/issues/6">#6</a>
+      for details.
     </p>
     <ul>
-      <li><a href="daily/nix.xml">nix</a>
-      <li><a href="daily/nixpkgs.xml">nixpkgs</a>
-      <li><a href="daily/nix-darwin.xml">nix-darwin</a>
-      <li><a href="daily/nixos.xml">NixOS</a>
-      <li><a href="daily/home-manager.xml">home-manager</a>
+      <li>
+        <a href="daily/nix.xml">nix</a> [<a href="daily-zeal/nix.xml">zeal</a>]
+      </li>
+      <li>
+        <a href="daily/nixpkgs.xml">nixpkgs</a> [<a
+          href="daily-zeal/nixpkgs.xml"
+          >zeal</a
+        >]
+      </li>
+      <li>
+        <a href="daily/nix-darwin.xml">nix-darwin</a> [<a
+          href="daily-zeal/nix-darwin.xml"
+          >zeal</a
+        >]
+      </li>
+      <li>
+        <a href="daily/nixos.xml">NixOS</a> [<a href="daily-zeal/nixos.xml"
+          >zeal</a
+        >]
+      </li>
+      <li>
+        <a href="daily/home-manager.xml">home-manager</a> [<a
+          href="daily-zeal/home-manager.xml"
+          >zeal</a
+        >]
+      </li>
     </ul>
   </body>
 </html>

--- a/src/mkNixDocsetFeed/default.nix
+++ b/src/mkNixDocsetFeed/default.nix
@@ -14,27 +14,19 @@
       else []
     );
 in
-  {baseURL}: let
-    feeds = lib.mapConcat (drv:
-      [(writeTextDir "${drv.pname}.xml" ''
-        <entry>
-          <name>${drv.pname}</name>
-          <url>${baseURL}/${drv.pname}.tgz</url>
-          <version>${drv.version}</version>
-        </entry>
-      ''
-      )
-      (writeTextDir "${drv.pname}-zeal.xml" ''
-        <entry>
-          <name>${drv.pname}</name>
-          <url>${baseURL}/${drv.pname}-zeal.tgz</url>
-          <version>${drv.version}</version>
-        </entry>
-      ''
-      )])
-    docsets;
+  {
+    baseURL,
+    zealCompat ? false,
+  }: let
+    feeds = builtins.map (drv: drv.updateFeed {inherit baseURL drv;}) docsets;
   in
     symlinkJoin {
       name = "nix-docset-feeds";
-      paths = docsets ++ feeds;
+      paths =
+        feeds
+        ++ (
+          if zealCompat
+          then builtins.map (drv: drv.zeal) docsets
+          else docsets
+        );
     }

--- a/src/mkNixDocsetFeed/default.nix
+++ b/src/mkNixDocsetFeed/default.nix
@@ -15,14 +15,23 @@
     );
 in
   {baseURL}: let
-    feeds = builtins.map (drv:
-      writeTextDir "${drv.pname}.xml" ''
+    feeds = lib.mapConcat (drv:
+      [(writeTextDir "${drv.pname}.xml" ''
         <entry>
-            <name>${drv.pname}</name>
-            <url>${baseURL}/${drv.pname}.tgz</url>
-            <version>${drv.version}</version>
-          </entry>
-      '')
+          <name>${drv.pname}</name>
+          <url>${baseURL}/${drv.pname}.tgz</url>
+          <version>${drv.version}</version>
+        </entry>
+      ''
+      )
+      (writeTextDir "${drv.pname}-zeal.xml" ''
+        <entry>
+          <name>${drv.pname}</name>
+          <url>${baseURL}/${drv.pname}-zeal.tgz</url>
+          <version>${drv.version}</version>
+        </entry>
+      ''
+      )])
     docsets;
   in
     symlinkJoin {


### PR DESCRIPTION
This PR refactors the feed-generation routines to live closer to the docset package that's being built, and generates a second feed for Zeal users, with a slightly different directory structure. The (now two) resulting feeds are linked from the deployed index page.

Fixes #6.