### PR TITLE
Use cache-nix-action & lix-quick-install-action in pages build

### DIFF
--- a/.github/workflows/publish_docsets.yml
+++ b/.github/workflows/publish_docsets.yml
@@ -12,12 +12,18 @@ on:
 
 jobs:
   build:
+    permissions:
+      actions: write
     name: "Build nix docsets and upload"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@V28
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - uses: canidae-solutions/lix-quick-install-action@v2
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
       - run: nix flake update
         working-directory: pages
       - run: nix build "./pages"


### PR DESCRIPTION
The magic nix cache is outdated, and I've switched to using lix for builds in all my other projects; let's use that.